### PR TITLE
Fix close being used instead of closesocket in GdbStub in Windows

### DIFF
--- a/src/debug/GdbStub.cpp
+++ b/src/debug/GdbStub.cpp
@@ -8,7 +8,6 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -19,6 +18,9 @@
 #include <signal.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
+// actually do the define for unix platforms rather than windows so that
+// it's clearer what the code does
+#define closesocket(x) close(x)
 #endif
 
 
@@ -138,11 +140,7 @@ bool GdbStub::Init(int port)
 err:
 	if (SockFd != 0)
 	{
-#ifdef _WIN32
 		closesocket(SockFd);
-#else
-		close(SockFd);
-#endif
 		SockFd = 0;
 	}
 
@@ -152,13 +150,13 @@ err:
 void GdbStub::Close()
 {
 	Disconnect();
-	if (SockFd > 0) close(SockFd);
+	if (SockFd > 0) closesocket(SockFd);
 	SockFd = 0;
 }
 
 void GdbStub::Disconnect()
 {
-	if (ConnFd > 0) close(ConnFd);
+	if (ConnFd > 0) closesocket(ConnFd);
 	ConnFd = 0;
 }
 
@@ -317,7 +315,7 @@ StubState GdbStub::Poll(bool wait)
 		if (WaitAckBlocking(&a, 1000) < 0)
 		{
 			Log(LogLevel::Error, "[GDB] inital handshake: didn't receive inital ack!\n");
-			close(ConnFd);
+			closesocket(ConnFd);
 			ConnFd = 0;
 			return StubState::Disconnect;
 		}
@@ -403,7 +401,7 @@ StubState GdbStub::Poll(bool wait)
 	case_gdbp_eof:
 	case ReadResult::Eof:
 		Log(LogLevel::Info, "[GDB] EOF!\n");
-		close(ConnFd);
+		closesocket(ConnFd);
 		ConnFd = 0;
 		return StubState::Disconnect;
 	case ReadResult::CksumErr:


### PR DESCRIPTION
The GdbStub was closing sockets on windows by using "close" rather than "closesocket"