### PR TITLE
Fix JIT linkage code for x86-64 in clang-cl builds

### DIFF
--- a/src/ARMJIT_x64/ARMJIT_Linkage.S
+++ b/src/ARMJIT_x64/ARMJIT_Linkage.S
@@ -20,6 +20,11 @@
 
 #include "ARMJIT_Offsets.h"
 
+// Fixes a stupid bug on clang-cl builds (defines _WIN64 but not _MSC_VER (this one is correct) or WIN64 (this one is MinGW weirdness))
+#if !defined(WIN64) && defined(_WIN64)
+#define WIN64 _WIN64
+#endif
+
 .text
 
 #define RCPU rbp


### PR DESCRIPTION
hi I did it :)